### PR TITLE
Stacks Navigation Improvements: show for long lists, respect order, scroll horizontally

### DIFF
--- a/components/BoardDetails.js
+++ b/components/BoardDetails.js
@@ -101,7 +101,7 @@ class BoardDetails extends React.Component {
                         ScrollView can use to make the containing view sticky,
                         without changing styles on the containing view */}
                         <View>
-                            <View style={styles.stackBar} >
+                            <ScrollView style={styles.stackBar} horizontal>
                                 {stacks.map(stack => (
                                     <DraxView
                                         key={stack.id}
@@ -127,7 +127,7 @@ class BoardDetails extends React.Component {
                                         </Pressable>
                                     </DraxView>
                                 ))}
-                            </View>
+                            </ScrollView>
                         </View>
                         {currentStack?.cards &&
                         <View>

--- a/components/BoardDetails.js
+++ b/components/BoardDetails.js
@@ -88,7 +88,6 @@ class BoardDetails extends React.Component {
             return (
                 <DraxProvider>
                     <ScrollView
-                        contentContainerStyle={styles.boardDetailsContainer}
                         refreshControl={
                             <RefreshControl
                                 refreshing={this.state.refreshing}
@@ -130,7 +129,7 @@ class BoardDetails extends React.Component {
                             </ScrollView>
                         </View>
                         {currentStack?.cards &&
-                        <View>
+                        <View style={styles.boardDetailsContainer}>
                             {Object.values(currentStack.cards).map(card => (
                                 <DraxView
                                     key={card.id}

--- a/components/BoardDetails.js
+++ b/components/BoardDetails.js
@@ -50,7 +50,8 @@ class BoardDetails extends React.Component {
     }
 
     render() {
-        if (this.props.boards.value[this.props.route.params.boardId].stacks.length === 0 && !this.state.refreshing) {
+        const stacks = this.props.boards.value[this.props.route.params.boardId].stacks;
+        if (stacks.length === 0 && !this.state.refreshing) {
             // Board has no stack
             return (
                 <View style={[styles.container, {marginBottom: this.insets.bottom}]}>
@@ -83,6 +84,7 @@ class BoardDetails extends React.Component {
                 </View>
             )
         } else {
+            const currentStack = stacks.find(oneStack => oneStack.id === this.state.index);
             return (
                 <DraxProvider>
                     <ScrollView
@@ -100,7 +102,7 @@ class BoardDetails extends React.Component {
                         without changing styles on the containing view */}
                         <View>
                             <View style={styles.stackBar} >
-                                {this.props.boards.value[this.props.route.params.boardId].stacks.map(stack => (
+                                {stacks.map(stack => (
                                     <DraxView
                                         key={stack.id}
                                         style={styles.stackTab}
@@ -127,10 +129,9 @@ class BoardDetails extends React.Component {
                                 ))}
                             </View>
                         </View>
-                        {typeof this.props.boards.value[this.props.route.params.boardId].stacks[this.state.index] !== 'undefined' &&
-                         typeof this.props.boards.value[this.props.route.params.boardId].stacks[this.state.index].cards !== 'undefined' &&
+                        {currentStack?.cards &&
                         <View>
-                            {Object.values(this.props.boards.value[this.props.route.params.boardId].stacks[this.state.index].cards).map(card => (
+                            {Object.values(currentStack.cards).map(card => (
                                 <DraxView
                                     key={card.id}
                                     payload={card.id}
@@ -200,6 +201,10 @@ class BoardDetails extends React.Component {
                     boardId: this.props.route.params.boardId,
                     stack: resp.data
                 })
+                // Select new stack
+                this.setState({
+                    index: this.props.boards.value[this.props.route.params.boardId].stacks[0].id,
+                })
             }
         })
         .catch((error) => {
@@ -229,10 +234,12 @@ class BoardDetails extends React.Component {
                     stack
                 })
             })
-            // Shows first stack
-            this.setState({
-                index: Math.min(...Object.keys(this.props.boards.value[this.props.route.params.boardId].stacks)),
-            })
+            // Shows stack with order === 0, if stacks are available
+            if (this.props.boards.value[this.props.route.params.boardId].stacks?.length) {
+                this.setState({
+                    index: this.props.boards.value[this.props.route.params.boardId].stacks[0].id,
+                })
+            }
         })
     }
 

--- a/components/BoardDetails.js
+++ b/components/BoardDetails.js
@@ -12,7 +12,7 @@ import { DraxProvider, DraxView } from 'react-native-drax';
 import axios from 'axios';
 import createStyles from '../styles/base.js'
 import { initialWindowMetrics } from 'react-native-safe-area-context';
-import {i18n} from '../i18n/i18n.js';
+import { i18n } from '../i18n/i18n.js';
 
 const styles = createStyles()
 
@@ -46,7 +46,7 @@ class BoardDetails extends React.Component {
         this.props.navigation.setOptions({
             headerTitle: 'Board details',
             headerRight: () => (<AppMenu/>)
-        })    
+        })
     }
 
     render() {
@@ -85,41 +85,48 @@ class BoardDetails extends React.Component {
         } else {
             return (
                 <DraxProvider>
-                    <View style={styles.stackBar} >
-                    {this.props.boards.value[this.props.route.params.boardId].stacks.map(stack => (
-                        <DraxView
-                            key={stack.id}
-                            style={styles.stackTab}
-                            receivingStyle={styles.stackTabDraggedOver}
-                            onReceiveDragDrop={({ dragged: { payload } }) => {
-                                console.log(`moving card ${payload}`);
-                                this.moveCard(payload, stack.id)
-                            }}
-                        >
-                            <Pressable
-                                key={stack.id}
-                                onPress={() => {
-                                    // Switches to selected stack
-                                    this.setState({
-                                        index: stack.id
-                                    })
-                                }}
-                            >
-                                <Text style={[styles.stackTabText, this.state.index === stack.id ? styles.stackTabTextSelected : styles.stackTabTextNormal]}>
-                                    {stack.title}
-                                </Text>
-                            </Pressable>
-                        </DraxView>
-                    ))}
-                    </View>
-                    <ScrollView contentContainerStyle={styles.container}
+                    <ScrollView
+                        contentContainerStyle={styles.boardDetailsContainer}
                         refreshControl={
-                            <RefreshControl                
+                            <RefreshControl
                                 refreshing={this.state.refreshing}
                                 onRefresh={this.loadBoard}
                             />
                         }
+                        stickyHeaderIndices={[0]}
                     >
+                        {/* This view is needed as an extra wrapper,
+                        ScrollView can use to make the containing view sticky,
+                        without changing styles on the containing view */}
+                        <View>
+                            <View style={styles.stackBar} >
+                                {this.props.boards.value[this.props.route.params.boardId].stacks.map(stack => (
+                                    <DraxView
+                                        key={stack.id}
+                                        style={styles.stackTab}
+                                        receivingStyle={styles.stackTabDraggedOver}
+                                        onReceiveDragDrop={({ dragged: { payload } }) => {
+                                            console.log(`moving card ${payload}`);
+                                            this.moveCard(payload, stack.id)
+                                        }}
+                                    >
+                                        <Pressable
+                                            key={stack.id}
+                                            onPress={() => {
+                                                // Switches to selected stack
+                                                this.setState({
+                                                    index: stack.id
+                                                })
+                                            }}
+                                        >
+                                            <Text style={[styles.stackTabText, this.state.index === stack.id ? styles.stackTabTextSelected : styles.stackTabTextNormal]}>
+                                                {stack.title}
+                                            </Text>
+                                        </Pressable>
+                                    </DraxView>
+                                ))}
+                            </View>
+                        </View>
                         {typeof this.props.boards.value[this.props.route.params.boardId].stacks[this.state.index] !== 'undefined' &&
                          typeof this.props.boards.value[this.props.route.params.boardId].stacks[this.state.index].cards !== 'undefined' &&
                         <View>
@@ -203,7 +210,7 @@ class BoardDetails extends React.Component {
     loadBoard() {
         this.setState({
             refreshing: true
-        })      
+        })
         axios.get(this.props.server.value + `/index.php/apps/deck/api/v1.0/boards/${this.props.route.params.boardId}/stacks`, {
             headers: {
                 'Content-Type': 'application/json',
@@ -213,12 +220,12 @@ class BoardDetails extends React.Component {
         .then((resp) => {
             this.setState({
                 refreshing: false
-            })          
+            })
             console.log('cards retrieved from server')
             // TODO check for error
             resp.data.forEach(stack => {
                 this.props.addStack({
-                    boardId: this.props.route.params.boardId, 
+                    boardId: this.props.route.params.boardId,
                     stack
                 })
             })
@@ -228,7 +235,7 @@ class BoardDetails extends React.Component {
             })
         })
     }
-    
+
     moveCard(cardId, stackId) {
         this.props.moveCard({
             boardId: this.props.route.params.boardId,

--- a/store/boardSlice.js
+++ b/store/boardSlice.js
@@ -10,7 +10,7 @@ export const boardSlice = createSlice({
       state.value[action.payload.id] = action.payload
     },
     addCard: (state, action) => {
-      state.value[action.payload.boardId].stacks[action.payload.stackId].cards[action.payload.card.id] = action.payload.card
+      state.value[action.payload.boardId].stacks.find(oneStack => oneStack.id === action.payload.stackId).cards[action.payload.card.id] = action.payload.card
     },
     addStack: (state, action) => {
       // Stores cards in an object where cards are indexed by their id rather than in an array
@@ -39,12 +39,12 @@ export const boardSlice = createSlice({
       state.value = {}
     },
     deleteCard: (state, action) => {
-      delete state.value[action.payload.boardId].stacks[action.payload.stackId].cards[action.payload.cardId]
+      delete state.value[action.payload.boardId].stacks.find(oneStack => oneStack.id === action.payload.stackId).cards[action.payload.cardId]
     },
     moveCard: (state, action) => {
-      const card = state.value[action.payload.boardId].stacks[action.payload.oldStackId].cards[action.payload.cardId]
-      state.value[action.payload.boardId].stacks[action.payload.newStackId].cards[action.payload.cardId] = card
-      delete state.value[action.payload.boardId].stacks[action.payload.oldStackId].cards[action.payload.cardId]
+      const card = state.value[action.payload.boardId].stacks.find(oneStack => oneStack.id === action.payload.oldStackId)?.cards[action.payload.cardId]
+      state.value[action.payload.boardId].stacks.find(oneStack => oneStack.id === action.payload.newStackId).cards[action.payload.cardId] = card
+      delete state.value[action.payload.boardId].stacks.find(oneStack => oneStack.id === action.payload.oldStackId).cards[action.payload.cardId]
     },
   }
 })

--- a/store/boardSlice.js
+++ b/store/boardSlice.js
@@ -21,8 +21,19 @@ export const boardSlice = createSlice({
           action.payload.stack.cards[card.id] = card
         })
       }
+      // Filter out existing stack with same id
+      if (state.value[action.payload.boardId].stacks?.length) {
+        state.value[action.payload.boardId].stacks = state.value[action.payload.boardId].stacks.filter(oneStack => oneStack.id !== action.payload.stack.id)
+      } else {
+        // Prepare empty stack array
+        state.value[action.payload.boardId].stacks = [];
+      }
       // Adds stack
-      state.value[action.payload.boardId].stacks[action.payload.stack.id] = action.payload.stack
+      state.value[action.payload.boardId].stacks.push(action.payload.stack)
+      // Sort stacks by order
+      state.value[action.payload.boardId].stacks.sort((a, b) => a.order - b.order)
+
+      return state
     },
     deleteAllBoards: (state, action) => {
       state.value = {}

--- a/styles/base.js
+++ b/styles/base.js
@@ -5,9 +5,10 @@ export const dimensions = {
   fullHeight: Dimensions.get('window').height,
   fullWidth: Dimensions.get('window').width
 }
-  
+
 export const colors  = {
   bg: '#fff',
+  bgDefault: '#f2f2f2',
   text: '#000',
   border: '#E5E5E5',
   // blueish
@@ -41,9 +42,17 @@ export const dropShadow = {
   elevation: 3,
 }
 
+const containerStyles = {
+  padding: padding.m,
+}
+
 const baseStyles = {
   container: {
-    padding: padding.m,
+    ...containerStyles
+  },
+  boardDetailsContainer: {
+    ...containerStyles,
+    paddingTop: 0,
   },
   title: {
     fontSize: fonts.xl,
@@ -95,10 +104,14 @@ const baseStyles = {
     maxHeight: 48,
     borderBottomColor: colors.border,
     borderBottomWidth: 1,
+    marginBottom: padding.m,
+    marginTop: padding.s,
+    backgroundColor: colors.bgDefault,
   },
   stackTab: {
     flexGrow: 1,
     justifyContent: 'center',
+    padding: padding.m,
   },
   stackTabDraggedOver: {
     backgroundColor: colors.bgInteract,

--- a/styles/base.js
+++ b/styles/base.js
@@ -101,12 +101,13 @@ const baseStyles = {
   stackBar: {
     flex: 1,
     flexDirection: 'row',
-    maxHeight: 48,
     borderBottomColor: colors.border,
     borderBottomWidth: 1,
     marginBottom: padding.m,
-    marginTop: padding.s,
     backgroundColor: colors.bgDefault,
+    width: '100%',
+    paddingLeft: padding.m,
+    paddingRight: padding.m,
   },
   stackTab: {
     flexGrow: 1,

--- a/styles/base.js
+++ b/styles/base.js
@@ -111,7 +111,6 @@ const baseStyles = {
   stackTab: {
     flexGrow: 1,
     justifyContent: 'center',
-    padding: padding.m,
   },
   stackTabDraggedOver: {
     backgroundColor: colors.bgInteract,
@@ -120,6 +119,7 @@ const baseStyles = {
     textAlign: 'center',
     textTransform: 'uppercase',
     color: colors.text,
+    padding: padding.m,
   },
   stackTabTextSelected: {
     fontWeight: 'bold'


### PR DESCRIPTION
Hey 👋 This is my first PR in this repository, so please let me know if there are any guidelines I should follow. Thanks!

### Summary
Several smaller improvements to navigating stacks  🪄 

### Details
- Makes stack navigation bar sticky
- Fixes stack navigation bar not visible for overflowing lists (more cards than screen can show)
- Makes stack navigation bar horizontally scrollable
- Respects order of stacks as reported by API

### Discussion
This PR changes the way stacks are added to the store, 
from basing the array's index on ids –> to basing the index on the order property,
creating a sorted array of stacks in the store

I'm up for discussion about this, if you'd rather not change store behavior. There are alternatives, like keeping a sorted copy of the list in local component state. I chose this approach, because it seems more future-proof to me.