### PR TITLE
Stack/List bar: Horizontal scrolling

### DIFF
--- a/components/BoardDetails.js
+++ b/components/BoardDetails.js
@@ -99,9 +99,11 @@ class BoardDetails extends React.Component {
                         ScrollView can use to make the containing view sticky,
                         without changing styles on the containing view */}
                         <View>
-                            <ScrollView style={this.props.theme.stackBar} 
+                            <ScrollView
+                                style={this.props.theme.stackBar}
                                 horizontal
-                                contentContainerStyle={{ flex: 1 }} >
+                                contentContainerStyle={this.props.theme.stackBarScrollInner}
+                            >
                                 {stacks.map(stack => (
                                     <DraxView
                                         key={stack.id}

--- a/styles/base.js
+++ b/styles/base.js
@@ -130,8 +130,11 @@ const baseStyles = (theme) => {
       marginBottom: padding.m,
       backgroundColor: colors.bgDefault,
       width: '100%',
-      paddingLeft: padding.m,
+    },
+    stackBarScrollInner: {
       paddingRight: padding.m,
+      paddingLeft: padding.m,
+      minWidth: '100%',
     },
     stackTab: {
       flexGrow: 1,


### PR DESCRIPTION
### Summary
Allows proper horizontal scrolling of the bar of lists / stacks.

### Details
Fixes the issue were the stack bar could not be scrolled all the way to the right, making it impossible to navigate to the later stacks. At the same time, it allows items to stretch if they don't fill the whole bar without using flex on the content container, because it disables scrolling.